### PR TITLE
Use plain old Exporter for the exports

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+end_of_line = LF
+indent_style = space
+indent_size = 4

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension {{$dist->name}}
 
 {{$NEXT}}
+    - Remove CPAN dependency on Attribute::Exporter
 
 0.103460  2010-12-12 01:37:17 PST8PDT
     - Removed unnecessary dependency on Perl v5.10

--- a/lib/List/Flatten/Recursive.pm
+++ b/lib/List/Flatten/Recursive.pm
@@ -5,8 +5,17 @@ use utf8;
 package List::Flatten::Recursive;
 # ABSTRACT: L<List::Flatten> with recursion
 
-require Attribute::Exporter;
-use base qw(Attribute::Exporter);
+require Exporter;
+our (@ISA, @EXPORT, @EXPORT_OK, %EXPORT_TAGS);
+BEGIN {
+    @ISA = qw(Exporter);
+    @EXPORT = qw(flat);
+    @EXPORT_OK = qw(flat flatten_to_listref);
+    %EXPORT_TAGS = (
+        default => [@EXPORT],
+        all => [@EXPORT, @EXPORT_OK],
+    );
+}
 
 use List::MoreUtils qw(any);
 
@@ -48,7 +57,7 @@ This function is exported by default.
 
 =cut
 
-sub flat :export_def {
+sub flat {
     return _flat(\@_);
 }
 
@@ -63,7 +72,7 @@ the following at the top of your program:
 
 =cut
 
-sub flatten_to_listref :export_ok {
+sub flatten_to_listref {
     return [ flat(@_) ];
 }
 


### PR DESCRIPTION
Thanks for this module!  I was not able to install it from CPAN.  I was able to install it from `master`, which uses Attribute::Explorer.

However, for some reason, Attribute::Exporter is greyed out in MetaCPAN ([ref](https://metacpan.org/release/AJWANS/Attribute-Exporter-0.02)).  Because I'm not sure why, and because Exporter is a core module, I am submitting this PR to switch `master` to Exporter.  I think using Exporter would be a good idea, since this module is so lightweight already and would get even lighter by using a core exporter module.

I also added an [EditorConfig](https://editorconfig.org) file to configure my editor to match what appears to me to be the project's style.

Thanks for considering this PR!

Replaces #1.